### PR TITLE
Strip Proxy-Authorization on redirect

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -483,21 +483,22 @@ mod redirect;
 
 /// Strategy for preserving authorization headers during redirects.
 ///
-/// This enum defines how authorization headers should be handled when following
-/// redirects:
+/// This enum defines how the `authorization` and `proxy-authorization` headers
+/// should be handled when following redirects:
 ///
-/// * `Never`: Never preserve the `authorization` header in redirects. This is the default.
-/// * `SameHost`: Preserve the `authorization` header when the redirect is to the same host
+/// * `Never`: Never preserve these headers in redirects. This is the default.
+/// * `SameHost`: Preserve these headers when the redirect is to the same host
 ///   and uses the same scheme (or switches to a more secure one, i.e., from HTTP to HTTPS,
 ///   but not the reverse).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum RedirectAuthHeaders {
-    /// Never preserve the `authorization` header on redirect. This is the default.
+    /// Never preserve the `authorization` or `proxy-authorization` header on redirect.
+    /// This is the default.
     Never,
-    /// Preserve the `authorization` header when the redirect is to the same host. Both hosts must use
-    /// the same scheme (or switch to a more secure one, i.e we can redirect from `http` to `https`,
-    /// but not the reverse).
+    /// Preserve the `authorization` and `proxy-authorization` headers when the redirect
+    /// is to the same host. Both hosts must use the same scheme (or switch to a more
+    /// secure one, i.e we can redirect from `http` to `https`, but not the reverse).
     SameHost,
 }
 

--- a/src/client/redirect.rs
+++ b/src/client/redirect.rs
@@ -84,9 +84,21 @@ impl Call<Redirect> {
         // Mutate the original request to remove headers we cannot keep in the redirect.
         let headers = request.headers_mut();
         if !keep_auth_header {
+            // Authorization is named in RFC 9110 §15.4 as a header to consider
+            // removing on redirect for security reasons.
             headers.remove(header::AUTHORIZATION);
+            // Proxy-Authorization is hop-scoped per RFC 9110 §11.7.2 ("applies only
+            // to the next inbound proxy"), and §15.4 lists it among headers to drop
+            // when redirecting.
+            headers.remove(header::PROXY_AUTHORIZATION);
         }
+        // Cookie is named alongside Authorization in RFC 9110 §15.4. Cookies for
+        // the redirect target are sourced from the cookie jar against the new URI,
+        // not carried from the previous request.
         headers.remove(header::COOKIE);
+        // Content-Length describes the body of the previous request. The redirect
+        // either changes method (e.g. POST -> GET, dropping the body entirely) or
+        // re-derives the length from a fresh body, so the old value cannot apply.
         headers.remove(header::CONTENT_LENGTH);
 
         // Next state

--- a/src/client/test/state_redirect.rs
+++ b/src/client/test/state_redirect.rs
@@ -348,6 +348,85 @@ fn dont_keep_auth_header_different_host() {
 }
 
 #[test]
+fn dont_keep_proxy_auth_header_never() {
+    let scenario = Scenario::builder()
+        .get("https://a.test/foo")
+        .header("proxy-authorization", "some secret")
+        .redirect(StatusCode::FOUND, "https://a.test/bar")
+        .build();
+
+    let mut call = scenario
+        .to_redirect()
+        .as_new_call(RedirectAuthHeaders::Never)
+        .unwrap()
+        .unwrap()
+        .proceed();
+
+    let mut o = vec![0; 1024];
+
+    let n = call.write(&mut o).unwrap();
+
+    let cmp = "\
+            GET /bar HTTP/1.1\r\n\
+            host: a.test\r\n\
+            \r\n";
+    assert_eq!(o[..n].as_str(), cmp);
+}
+
+#[test]
+fn keep_proxy_auth_header_same_host() {
+    let scenario = Scenario::builder()
+        .get("https://a.test:123/foo")
+        .header("proxy-authorization", "some secret")
+        .redirect(StatusCode::FOUND, "https://a.test:234/bar")
+        .build();
+
+    let mut call = scenario
+        .to_redirect()
+        .as_new_call(RedirectAuthHeaders::SameHost)
+        .unwrap()
+        .unwrap()
+        .proceed();
+
+    let mut o = vec![0; 1024];
+
+    let n = call.write(&mut o).unwrap();
+
+    let cmp = "\
+            GET /bar HTTP/1.1\r\n\
+            host: a.test:234\r\n\
+            proxy-authorization: some secret\r\n\
+            \r\n";
+    assert_eq!(o[..n].as_str(), cmp);
+}
+
+#[test]
+fn dont_keep_proxy_auth_header_different_host() {
+    let scenario = Scenario::builder()
+        .get("https://a.test/foo")
+        .header("proxy-authorization", "some secret")
+        .redirect(StatusCode::FOUND, "https://b.test/bar")
+        .build();
+
+    let mut call = scenario
+        .to_redirect()
+        .as_new_call(RedirectAuthHeaders::SameHost)
+        .unwrap()
+        .unwrap()
+        .proceed();
+
+    let mut o = vec![0; 1024];
+
+    let n = call.write(&mut o).unwrap();
+
+    let cmp = "\
+            GET /bar HTTP/1.1\r\n\
+            host: b.test\r\n\
+            \r\n";
+    assert_eq!(o[..n].as_str(), cmp);
+}
+
+#[test]
 fn dont_keep_cookie_header() {
     let scenario = Scenario::builder()
         .get("https://a.test/foo")


### PR DESCRIPTION
## Summary

- Drop the `Proxy-Authorization` header when constructing a redirected request, mirroring how we already handle `Authorization`. Retention is gated through `RedirectAuthHeaders::SameHost`.
- Add inline RFC citations for the headers we strip on redirect (`Authorization`, `Proxy-Authorization`, `Cookie`, `Content-Length`).
- Update `RedirectAuthHeaders` doc comments to mention `proxy-authorization` alongside `authorization`.

## Rationale

Per RFC 9110 §11.7.2, `Proxy-Authorization` is hop-scoped — it "applies only to the next inbound proxy that demanded authentication" — and §15.4 explicitly lists it among the headers to remove when redirecting. A redirect crosses hops by definition, so the previous proxy credentials cannot be valid for the new request.

This matches what `reqwest` does (`remove_sensitive_headers` strips `Proxy-Authorization` alongside `Authorization` and `Cookie`).
