### PR TITLE
Keep headers after an empty value in the partial response parser

### DIFF
--- a/src/client/test/state_recv_response.rs
+++ b/src/client/test/state_recv_response.rs
@@ -52,6 +52,32 @@ fn receive_complete_response() {
 }
 
 #[test]
+fn partial_redirect_with_empty_header_value() {
+    // Broken servers may omit the final \r\n of a redirect. With
+    // allow_partial_redirect we accept the redirect from the partial
+    // headers. An empty header value before Location must not hide it.
+    let input: &[u8] = b"\
+        HTTP/1.1 302 Found\r\n\
+        X-Empty:\r\n\
+        Location: https://q.test/other\r\n";
+
+    let scenario = Scenario::builder().get("https://q.test").build();
+    let mut call = scenario.to_recv_response();
+
+    let (input_used, maybe_response) = call.try_response(input, true).unwrap();
+    assert_eq!(input_used, input.len());
+
+    let response = maybe_response.expect("partial redirect detected");
+    assert_eq!(response.status(), StatusCode::FOUND);
+    assert_eq!(
+        response.headers().get(header::LOCATION).unwrap(),
+        "https://q.test/other"
+    );
+    assert!(response.headers().iter().has(header::CONNECTION, "close"));
+    assert!(call.can_proceed());
+}
+
+#[test]
 fn prepended_100_continue() {
     // In the case of expect-100-continue, there's a chance the 100-continue
     // arrives after we started sending the request body, in which case

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -242,6 +242,26 @@ mod test {
     }
 
     #[test]
+    fn partial_response_keeps_headers_after_empty_value() {
+        // An empty header value is legal. The partial parser must not
+        // mistake it for the end of the parsed headers and drop the rest.
+        let bytes = "HTTP/1.1 302 Found\r\n\
+            X-Empty:\r\n\
+            Location: http://example.com/\r\n";
+
+        let res = try_parse_partial_response::<20>(bytes.as_bytes())
+            .expect("parse ok")
+            .expect("status line complete");
+
+        assert_eq!(res.status().as_u16(), 302);
+        assert_eq!(res.headers().get("x-empty").expect("x-empty present"), "");
+        assert_eq!(
+            res.headers().get("location").expect("location present"),
+            "http://example.com/"
+        );
+    }
+
+    #[test]
     fn boundary_status_codes_parse() {
         let bytes = "HTTP/1.1 100 Continue\r\n\r\n";
         let (_, res) = try_parse_response::<20>(bytes.as_bytes())

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -122,7 +122,12 @@ pub fn try_parse_partial_response<const N: usize>(
     let mut builder = Response::builder().version(version).status(status);
 
     for h in res.headers {
-        if h.name.is_empty() || h.value.is_empty() {
+        // On a partial parse, httparse leaves the unparsed slots as
+        // EMPTY_HEADER. A parsed header always has a non-empty name, since
+        // the first byte of a header line must be a token character. The
+        // value however can legitimately be empty, so only the name tells
+        // us where the parsed headers end.
+        if h.name.is_empty() {
             break;
         }
         builder = builder.header(h.name, h.value);


### PR DESCRIPTION
## Summary

`try_parse_partial_response` detected the end of the headers httparse managed to parse by breaking on an empty name **or** an empty value. An empty header value is legal HTTP, so a header such as `X-Empty:` caused every later header to be dropped from the partial parse. In the client this hid a `Location` header behind an empty-valued header when accepting a partial redirect from a broken server that omits the final `\r\n`.

The loop now breaks only on an empty name. A parsed header always has a non-empty name, since httparse requires the first byte of a header line to be a token character, so the name alone identifies the unparsed `EMPTY_HEADER` slots.

Adds a parser test that a partial `302` with `X-Empty:` before `Location` keeps both headers, and a client state-machine test that the same response is accepted as a partial redirect with `allow_partial_redirect`.
