### PR TITLE
Match Connection header options as case-insensitive tokens

### DIFF
--- a/src/client/test/state_cleanup.rs
+++ b/src/client/test/state_cleanup.rs
@@ -155,3 +155,70 @@ fn close_due_to_close_delimited_body() {
 
     assert!(call.must_close_connection());
 }
+
+// Connection options are comma-separated tokens compared case-insensitively.
+// https://www.rfc-editor.org/rfc/rfc9110#section-7.6.1
+
+#[test]
+fn close_due_to_server_connection_close_capitalized() {
+    let scenario = Scenario::builder()
+        .get("https://a.test")
+        .response(
+            Response::builder()
+                .header("connection", "Close")
+                .body(())
+                .unwrap(),
+        )
+        .build();
+
+    let call = scenario.to_cleanup();
+    let inner = call.inner();
+    assert!(
+        inner
+            .close_reason
+            .contains(&CloseReason::ServerConnectionClose)
+    );
+
+    assert!(call.must_close_connection());
+}
+
+#[test]
+fn close_due_to_server_connection_close_in_list() {
+    let scenario = Scenario::builder()
+        .get("https://a.test")
+        .response(
+            Response::builder()
+                .header("connection", "keep-alive, close")
+                .body(())
+                .unwrap(),
+        )
+        .build();
+
+    let call = scenario.to_cleanup();
+    let inner = call.inner();
+    assert!(
+        inner
+            .close_reason
+            .contains(&CloseReason::ServerConnectionClose)
+    );
+
+    assert!(call.must_close_connection());
+}
+
+#[test]
+fn close_due_to_client_connection_close_capitalized() {
+    let scenario = Scenario::builder()
+        .get("https://a.test")
+        .header("connection", "Close")
+        .build();
+
+    let call = scenario.to_cleanup();
+    let inner = call.inner();
+    assert!(
+        inner
+            .close_reason
+            .contains(&CloseReason::ClientConnectionClose)
+    );
+
+    assert!(call.must_close_connection());
+}

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -149,3 +149,71 @@ impl AuthorityExt for http::uri::Authority {
             .and_then(|a| a.rfind(':').map(|i| &a[i + 1..]))
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use http::HeaderMap;
+
+    fn headers(lines: &[(&'static str, &'static str)]) -> HeaderMap {
+        let mut map = HeaderMap::new();
+        for (name, value) in lines {
+            map.append(*name, HeaderValue::from_static(value));
+        }
+        map
+    }
+
+    // Connection options are comma-separated tokens compared case-insensitively.
+    // https://www.rfc-editor.org/rfc/rfc9110#section-7.6.1
+
+    #[test]
+    fn has_is_case_insensitive() {
+        let h = headers(&[("connection", "Close")]);
+        assert!(h.iter().has(header::CONNECTION, "close"));
+
+        let h = headers(&[("connection", "Keep-Alive")]);
+        assert!(h.iter().has(header::CONNECTION, "keep-alive"));
+    }
+
+    #[test]
+    fn has_finds_element_in_list() {
+        let h = headers(&[("connection", "keep-alive, close")]);
+        assert!(h.iter().has(header::CONNECTION, "close"));
+        assert!(h.iter().has(header::CONNECTION, "keep-alive"));
+
+        let h = headers(&[("connection", "close,Upgrade")]);
+        assert!(h.iter().has(header::CONNECTION, "close"));
+        assert!(h.iter().has(header::CONNECTION, "upgrade"));
+    }
+
+    #[test]
+    fn has_across_repeated_lines() {
+        let h = headers(&[("connection", "keep-alive"), ("connection", "close")]);
+        assert!(h.iter().has(header::CONNECTION, "close"));
+    }
+
+    #[test]
+    fn has_no_partial_or_wrong_header_match() {
+        let h = headers(&[("connection", "closed")]);
+        assert!(!h.iter().has(header::CONNECTION, "close"));
+
+        let h = headers(&[("connection", "keep-alive")]);
+        assert!(!h.iter().has(header::CONNECTION, "close"));
+
+        let h = headers(&[("upgrade", "close")]);
+        assert!(!h.iter().has(header::CONNECTION, "close"));
+
+        let h = headers(&[("connection", "")]);
+        assert!(!h.iter().has(header::CONNECTION, "close"));
+    }
+
+    #[test]
+    fn has_expect_100_is_case_insensitive() {
+        // https://www.rfc-editor.org/rfc/rfc9110#section-10.1.1
+        let h = headers(&[("expect", "100-Continue")]);
+        assert!(h.iter().has_expect_100());
+
+        let h = headers(&[("expect", "100-continue")]);
+        assert!(h.iter().has_expect_100());
+    }
+}

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -1,5 +1,7 @@
 use http::{HeaderName, HeaderValue, Method, StatusCode, header};
 
+use crate::util::compare_lowercase_ascii;
+
 #[cfg(feature = "server")]
 pub(crate) trait StatusCodeExt {
     /// Check if the status code requires a body according to HTTP spec.
@@ -76,13 +78,23 @@ impl MethodExt for Method {
 }
 
 pub(crate) trait HeaderIterExt {
-    fn has(self, key: HeaderName, value: &str) -> bool;
+    /// Whether any header line named `key` lists `token` as one of its
+    /// comma-separated elements.
+    ///
+    /// Elements are trimmed of surrounding whitespace and compared ASCII
+    /// case-insensitively, as required for list-based fields such as
+    /// `Connection` (RFC 9110 §7.6.1) and `Expect` (RFC 9110 §10.1.1).
+    /// `token` must be given in lowercase.
+    fn has(self, key: HeaderName, token: &str) -> bool;
     fn has_expect_100(self) -> bool;
 }
 
 impl<'a, I: Iterator<Item = (&'a HeaderName, &'a HeaderValue)>> HeaderIterExt for I {
-    fn has(self, key: HeaderName, value: &str) -> bool {
-        self.filter(|i| i.0 == key).any(|i| i.1 == value)
+    fn has(self, key: HeaderName, token: &str) -> bool {
+        self.filter(|(name, _)| **name == key)
+            .filter_map(|(_, value)| value.to_str().ok())
+            .flat_map(|value| value.split(','))
+            .any(|element| compare_lowercase_ascii(element.trim(), token))
     }
 
     fn has_expect_100(self) -> bool {

--- a/src/server/test/state_cleanup.rs
+++ b/src/server/test/state_cleanup.rs
@@ -146,3 +146,91 @@ fn close_due_to_http10() {
         CloseReason::CloseDelimitedBody
     );
 }
+
+// Connection options are comma-separated tokens compared case-insensitively.
+// https://www.rfc-editor.org/rfc/rfc9110#section-7.6.1
+
+#[test]
+fn close_due_to_client_connection_close_capitalized() {
+    let scenario = Scenario::builder()
+        .request(
+            Request::get("/path")
+                .header("connection", "Close")
+                .body(())
+                .unwrap(),
+        )
+        .response(
+            Response::builder()
+                .status(200)
+                .header("content-length", "0")
+                .body(())
+                .unwrap(),
+        )
+        .build();
+
+    let reply = scenario.to_cleanup();
+
+    assert!(reply.must_close_connection());
+
+    let inner = reply.inner();
+    assert!(
+        inner
+            .close_reason
+            .contains(&CloseReason::ClientConnectionClose)
+    );
+}
+
+#[test]
+fn close_due_to_client_connection_close_in_list() {
+    let scenario = Scenario::builder()
+        .request(
+            Request::get("/path")
+                .header("connection", "keep-alive, close")
+                .body(())
+                .unwrap(),
+        )
+        .response(
+            Response::builder()
+                .status(200)
+                .header("content-length", "0")
+                .body(())
+                .unwrap(),
+        )
+        .build();
+
+    let reply = scenario.to_cleanup();
+
+    assert!(reply.must_close_connection());
+
+    let inner = reply.inner();
+    assert!(
+        inner
+            .close_reason
+            .contains(&CloseReason::ClientConnectionClose)
+    );
+}
+
+#[test]
+fn http10_with_keep_alive_capitalized() {
+    // "Connection: Keep-Alive" is the common spelling in the wild.
+    let scenario = Scenario::builder()
+        .request(
+            Request::get("/path")
+                .version(Version::HTTP_10)
+                .header("connection", "Keep-Alive")
+                .body(())
+                .unwrap(),
+        )
+        .response(
+            Response::builder()
+                .status(200)
+                .header("content-length", "0")
+                .body(())
+                .unwrap(),
+        )
+        .build();
+
+    let reply = scenario.to_cleanup();
+
+    assert!(!reply.must_close_connection());
+}


### PR DESCRIPTION
## Summary

`HeaderIterExt::has` compared the whole header value exactly and case-sensitively, so `Connection: Close`, `Connection: keep-alive, close` and `Expect: 100-Continue` were not recognised. RFC 9110 §7.6.1 defines Connection options as comma-separated tokens compared case-insensitively, and §10.1.1 says the same for the `100-continue` expectation. A missed close on the client side meant the connection went back to the pool, and a missed `Keep-Alive` on an HTTP/1.0 request made the server close a reusable connection.

The matcher now splits every line of the named header on commas, trims each element and compares it ASCII case-insensitively, reusing the crate's existing `compare_lowercase_ascii` helper. Repeated header lines are still all considered. Call sites in the client (`recvresp.rs`, `prepare.rs`) and server (`recvreq.rs`) are unchanged.

Tests added:

- Unit tests for the matcher in `src/ext.rs`: capitalised value, element inside a list (with and without a space after the comma), repeated header lines, no partial match (`closed`), no match on a different header name, empty value, and `Expect: 100-Continue`.
- Client cleanup tests: server response `Connection: Close`, server response `Connection: keep-alive, close`, and client request `Connection: Close`, each asserting the close reason and `must_close_connection()`.
- Server cleanup tests: request `Connection: Close`, request `Connection: keep-alive, close`, and an HTTP/1.0 request with `Connection: Keep-Alive` that must keep the connection open.
