### PR TITLE
Align Content-Length handling with libcurl

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -542,7 +542,13 @@ pub(crate) fn parse_content_length<'a>(
     Ok(result)
 }
 
-fn parse_content_length_value(value: &[u8]) -> Result<u64, Error> {
+/// Parse one `Content-Length` value: `1*DIGIT` with optional surrounding
+/// whitespace, nothing else.
+///
+/// This is the grammar a sender must produce (RFC 9110 §8.6), so it is what
+/// the outgoing request and response analyzers use. The list tolerance in
+/// [`parse_content_length`] is for received messages only.
+pub(crate) fn parse_content_length_value(value: &[u8]) -> Result<u64, Error> {
     let trimmed = trim_ows(value);
 
     if trimmed.is_empty() || !trimmed.iter().all(u8::is_ascii_digit) {

--- a/src/body.rs
+++ b/src/body.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::io::Write;
 
-use http::{HeaderName, HeaderValue, Method, header};
+use http::{HeaderMap, HeaderName, HeaderValue, Method, header};
 
 use crate::Error;
 use crate::chunk::Dechunker;
@@ -268,11 +268,11 @@ impl BodyReader {
     }
 
     #[cfg(feature = "server")]
-    pub fn for_request<'a>(
+    pub fn for_request(
         http10: bool,
         method: &Method,
         force_send: bool,
-        header_lookup: &'a dyn Fn(http::HeaderName) -> Option<&'a str>,
+        headers: &HeaderMap,
     ) -> Result<Self, Error> {
         use crate::ext::MethodExt;
 
@@ -280,7 +280,7 @@ impl BodyReader {
             return Ok(Self::NoBody);
         }
 
-        let ret = Self::header_defined(http10, header_lookup)?.unwrap_or_else(|| {
+        let ret = Self::header_defined(http10, headers)?.unwrap_or_else(|| {
             if !http10 && method.need_request_body() {
                 Self::Chunked(Dechunker::new())
             } else {
@@ -293,15 +293,14 @@ impl BodyReader {
 
     #[cfg(feature = "client")]
     // https://datatracker.ietf.org/doc/html/rfc2616#section-4.3
-    pub fn for_response<'a>(
+    pub fn for_response(
         http10: bool,
         method: &Method,
         status_code: u16,
         force_recv: bool,
-        header_lookup: &'a dyn Fn(HeaderName) -> Option<&'a str>,
+        headers: &HeaderMap,
     ) -> Result<Self, Error> {
-        let header_defined =
-            Self::header_defined(http10, header_lookup)?.unwrap_or(Self::CloseDelimited);
+        let header_defined = Self::header_defined(http10, headers)?.unwrap_or(Self::CloseDelimited);
 
         // Is body mode being defined in headers?
         let body_mode_defined = header_defined.body_mode() != BodyMode::CloseDelimited;
@@ -322,25 +321,15 @@ impl BodyReader {
         }
     }
 
-    fn header_defined<'a>(
-        http10: bool,
-        header_lookup: &'a dyn Fn(HeaderName) -> Option<&'a str>,
-    ) -> Result<Option<Self>, Error> {
-        let mut content_length: Option<u64> = None;
+    fn header_defined(http10: bool, headers: &HeaderMap) -> Result<Option<Self>, Error> {
+        let content_length = parse_content_length(headers.get_all(header::CONTENT_LENGTH).iter())?;
+
         let mut chunked = false;
 
-        // for head in headers {
-        if let Some(value) = header_lookup(header::CONTENT_LENGTH) {
-            let v = value
-                .parse::<u64>()
-                .map_err(|_| Error::BadContentLengthHeader)?;
-            if content_length.is_some() {
-                return Err(Error::TooManyContentLengthHeaders);
-            }
-            content_length = Some(v);
-        }
-
-        if let Some(value) = header_lookup(header::TRANSFER_ENCODING) {
+        if let Some(value) = headers
+            .get(header::TRANSFER_ENCODING)
+            .and_then(|v| v.to_str().ok())
+        {
             // Header can repeat, stop looking if we found "chunked"
             chunked = value
                 .split(',')
@@ -519,9 +508,123 @@ impl fmt::Debug for BodyReader {
     }
 }
 
+/// Parse the `Content-Length` of a message from all of its header lines.
+///
+/// This follows RFC 9110 §8.6 and RFC 9112 §6.3 the way libcurl does.
+///
+/// * A value is `1*DIGIT`. Leading zeros are allowed. A sign, whitespace
+///   inside the number or any other character is an error.
+/// * Repeated header lines are equivalent to one comma separated list
+///   (RFC 9110 §5.3). Every element must be a valid value and all elements
+///   must be the same number, `42` and `042` included. Differing values are
+///   rejected, there is no first-wins or last-wins.
+/// * An empty value, an empty list element and a number that does not fit
+///   in a `u64` are errors.
+///
+/// Returns `Ok(None)` when there is no `Content-Length` header at all.
+pub(crate) fn parse_content_length<'a>(
+    values: impl Iterator<Item = &'a HeaderValue>,
+) -> Result<Option<u64>, Error> {
+    let mut result = None;
+
+    for value in values {
+        for element in value.as_bytes().split(|b| *b == b',') {
+            let n = parse_content_length_value(element)?;
+
+            if result.is_some_and(|prev| prev != n) {
+                return Err(Error::TooManyContentLengthHeaders);
+            }
+
+            result = Some(n);
+        }
+    }
+
+    Ok(result)
+}
+
+fn parse_content_length_value(value: &[u8]) -> Result<u64, Error> {
+    let trimmed = trim_ows(value);
+
+    if trimmed.is_empty() || !trimmed.iter().all(u8::is_ascii_digit) {
+        return Err(Error::BadContentLengthHeader);
+    }
+
+    // Only ASCII digits, so this is valid UTF-8 and cannot carry a sign.
+    // A number too large for u64 fails to parse.
+    std::str::from_utf8(trimmed)
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .ok_or(Error::BadContentLengthHeader)
+}
+
+/// Strip optional whitespace (SP / HTAB) from both ends.
+fn trim_ows(mut b: &[u8]) -> &[u8] {
+    while let [b' ' | b'\t', rest @ ..] = b {
+        b = rest;
+    }
+    while let [rest @ .., b' ' | b'\t'] = b {
+        b = rest;
+    }
+    b
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
+
+    fn cl(values: &[&str]) -> Result<Option<u64>, Error> {
+        let headers: Vec<HeaderValue> = values
+            .iter()
+            .map(|v| HeaderValue::from_bytes(v.as_bytes()).unwrap())
+            .collect();
+        parse_content_length(headers.iter())
+    }
+
+    #[test]
+    fn content_length_single_values() {
+        assert_eq!(cl(&[]), Ok(None));
+        assert_eq!(cl(&["0"]), Ok(Some(0)));
+        assert_eq!(cl(&["42"]), Ok(Some(42)));
+        assert_eq!(cl(&["042"]), Ok(Some(42)));
+        assert_eq!(cl(&[" 42 "]), Ok(Some(42)));
+        assert_eq!(cl(&["18446744073709551615"]), Ok(Some(u64::MAX)));
+    }
+
+    #[test]
+    fn content_length_repeats_must_agree() {
+        assert_eq!(cl(&["42", "42"]), Ok(Some(42)));
+        assert_eq!(cl(&["42, 42"]), Ok(Some(42)));
+        assert_eq!(cl(&["42", "042"]), Ok(Some(42)));
+        assert_eq!(cl(&["42,42", "42"]), Ok(Some(42)));
+        assert_eq!(cl(&["42", "43"]), Err(Error::TooManyContentLengthHeaders));
+        assert_eq!(cl(&["42, 43"]), Err(Error::TooManyContentLengthHeaders));
+        assert_eq!(
+            cl(&["43", "42, 42"]),
+            Err(Error::TooManyContentLengthHeaders)
+        );
+    }
+
+    #[test]
+    fn content_length_must_be_digits() {
+        assert_eq!(cl(&["+42"]), Err(Error::BadContentLengthHeader));
+        assert_eq!(cl(&["-1"]), Err(Error::BadContentLengthHeader));
+        assert_eq!(cl(&["4 2"]), Err(Error::BadContentLengthHeader));
+        assert_eq!(cl(&["42abc"]), Err(Error::BadContentLengthHeader));
+        assert_eq!(cl(&["0x2a"]), Err(Error::BadContentLengthHeader));
+        assert_eq!(cl(&[""]), Err(Error::BadContentLengthHeader));
+        assert_eq!(cl(&["  "]), Err(Error::BadContentLengthHeader));
+        assert_eq!(cl(&["42,"]), Err(Error::BadContentLengthHeader));
+        assert_eq!(cl(&["42,,42"]), Err(Error::BadContentLengthHeader));
+        assert_eq!(cl(&["42", ""]), Err(Error::BadContentLengthHeader));
+        assert_eq!(
+            cl(&["18446744073709551616"]),
+            Err(Error::BadContentLengthHeader)
+        );
+        assert_eq!(
+            cl(&["99999999999999999999999"]),
+            Err(Error::BadContentLengthHeader)
+        );
+    }
 
     #[test]
     fn test_calculate_max_input() {

--- a/src/client/amended.rs
+++ b/src/client/amended.rs
@@ -4,7 +4,7 @@ use http::uri::PathAndQuery;
 use http::{HeaderMap, HeaderName, HeaderValue, Method, Request, Uri, Version, header};
 
 use crate::Error;
-use crate::body::{BodyWriter, parse_content_length};
+use crate::body::{BodyWriter, parse_content_length_value};
 use crate::ext::MethodExt;
 use crate::util::compare_lowercase_ascii;
 
@@ -169,8 +169,12 @@ impl AmendedRequest {
             req_auth_header = true;
         }
 
-        let content_length =
-            parse_content_length(self.headers_get(header::CONTENT_LENGTH).into_iter())?;
+        // We control what we send: a single header line holding a single
+        // number. A comma separated list must not reach the wire.
+        let content_length = self
+            .headers_get(header::CONTENT_LENGTH)
+            .map(|h| parse_content_length_value(h.as_bytes()))
+            .transpose()?;
 
         let has_chunked = self
             .headers_get_all(header::TRANSFER_ENCODING)

--- a/src/client/amended.rs
+++ b/src/client/amended.rs
@@ -4,7 +4,7 @@ use http::uri::PathAndQuery;
 use http::{HeaderMap, HeaderName, HeaderValue, Method, Request, Uri, Version, header};
 
 use crate::Error;
-use crate::body::BodyWriter;
+use crate::body::{BodyWriter, parse_content_length};
 use crate::ext::MethodExt;
 use crate::util::compare_lowercase_ascii;
 
@@ -169,15 +169,8 @@ impl AmendedRequest {
             req_auth_header = true;
         }
 
-        let mut content_length: Option<u64> = None;
-        if let Some(h) = self.headers_get(header::CONTENT_LENGTH) {
-            let n = h
-                .to_str()
-                .ok()
-                .and_then(|s| s.parse::<u64>().ok())
-                .ok_or(Error::BadContentLengthHeader)?;
-            content_length = Some(n);
-        }
+        let content_length =
+            parse_content_length(self.headers_get(header::CONTENT_LENGTH).into_iter())?;
 
         let has_chunked = self
             .headers_get_all(header::TRANSFER_ENCODING)

--- a/src/client/recvresp.rs
+++ b/src/client/recvresp.rs
@@ -1,4 +1,4 @@
-use http::{HeaderName, HeaderValue, Response, StatusCode, Version, header};
+use http::{HeaderValue, Response, StatusCode, Version, header};
 
 use crate::Error;
 use crate::body::BodyReader;
@@ -142,18 +142,13 @@ impl Call<RecvResponse> {
             return Ok(Some((input_used, response)));
         }
 
-        let header_lookup = |name: HeaderName| {
-            let header = response.headers().get(name)?;
-            header.to_str().ok()
-        };
-
         let force_recv = self.inner.force_recv_body;
         let recv_body_mode = BodyReader::for_response(
             http10,
             self.inner.request.method(),
             status,
             force_recv,
-            &header_lookup,
+            response.headers(),
         )?;
 
         self.inner.state.reader = Some(recv_body_mode);

--- a/src/client/test/state_recv_response.rs
+++ b/src/client/test/state_recv_response.rs
@@ -382,3 +382,13 @@ fn content_length_with_sign_is_rejected() {
     let err = call.try_response(input, false).unwrap_err();
     assert_eq!(err, Error::BadContentLengthHeader);
 }
+
+#[test]
+fn empty_content_length_is_rejected() {
+    let input: &[u8] = b"HTTP/1.1 200 OK\r\nContent-Length:\r\n\r\n";
+    let scenario = Scenario::builder().get("https://q.test").build();
+    let mut call = scenario.to_recv_response();
+
+    let err = call.try_response(input, false).unwrap_err();
+    assert_eq!(err, Error::BadContentLengthHeader);
+}

--- a/src/client/test/state_recv_response.rs
+++ b/src/client/test/state_recv_response.rs
@@ -1,5 +1,6 @@
 use http::{StatusCode, Version, header};
 
+use crate::Error;
 use crate::client::test::scenario::Scenario;
 use crate::ext::HeaderIterExt;
 
@@ -325,4 +326,59 @@ fn multiple_103_before_final_response() {
 
     let response = maybe_response.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
+}
+
+// Content-Length handling follows RFC 9110 §8.6 / RFC 9112 §6.3 the way
+// libcurl does: repeated header lines and comma separated lists are fine as
+// long as every value is the same number, differing values are an error, and
+// a value must be plain digits.
+
+#[test]
+fn duplicate_identical_content_length_is_accepted() {
+    let input: &[u8] = b"\
+        HTTP/1.1 200 OK\r\n\
+        Content-Length: 42\r\n\
+        Content-Length: 042\r\n\
+        \r\n";
+    let scenario = Scenario::builder().get("https://q.test").build();
+    let mut call = scenario.to_recv_response();
+
+    let (input_used, maybe_response) = call.try_response(input, false).unwrap();
+    assert_eq!(input_used, input.len());
+    assert!(maybe_response.is_some());
+    assert!(call.can_proceed());
+}
+
+#[test]
+fn duplicate_differing_content_length_is_rejected() {
+    let input: &[u8] = b"\
+        HTTP/1.1 200 OK\r\n\
+        Content-Length: 42\r\n\
+        Content-Length: 43\r\n\
+        \r\n";
+    let scenario = Scenario::builder().get("https://q.test").build();
+    let mut call = scenario.to_recv_response();
+
+    let err = call.try_response(input, false).unwrap_err();
+    assert_eq!(err, Error::TooManyContentLengthHeaders);
+}
+
+#[test]
+fn content_length_list_with_differing_values_is_rejected() {
+    let input: &[u8] = b"HTTP/1.1 200 OK\r\nContent-Length: 42, 43\r\n\r\n";
+    let scenario = Scenario::builder().get("https://q.test").build();
+    let mut call = scenario.to_recv_response();
+
+    let err = call.try_response(input, false).unwrap_err();
+    assert_eq!(err, Error::TooManyContentLengthHeaders);
+}
+
+#[test]
+fn content_length_with_sign_is_rejected() {
+    let input: &[u8] = b"HTTP/1.1 200 OK\r\nContent-Length: +42\r\n\r\n";
+    let scenario = Scenario::builder().get("https://q.test").build();
+    let mut call = scenario.to_recv_response();
+
+    let err = call.try_response(input, false).unwrap_err();
+    assert_eq!(err, Error::BadContentLengthHeader);
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -48,7 +48,7 @@ impl fmt::Display for Error {
                 write!(f, "{} not valid for HTTP version {:?}", m, v)
             }
             Error::TooManyHostHeaders => write!(f, "more than one host header"),
-            Error::TooManyContentLengthHeaders => write!(f, "more than one content-length header"),
+            Error::TooManyContentLengthHeaders => write!(f, "conflicting content-length headers"),
             Error::BadHostHeader => write!(f, "host header is not a string"),
             Error::BadAuthorizationHeader => write!(f, "authorization header is not a string"),
             Error::BadContentLengthHeader => write!(f, "content-length header not a number"),

--- a/src/error.rs
+++ b/src/error.rs
@@ -243,6 +243,29 @@ mod tests_client {
         assert!(matches!(err, Error::BadContentLengthHeader));
     }
 
+    // BadContentLengthHeader
+    #[test]
+    fn test_list_content_length_header() {
+        // We control what we send. A comma separated list is not a valid
+        // Content-Length to send (RFC 9110 §8.6: the value is 1*DIGIT), so
+        // it must be rejected here rather than written to the wire verbatim.
+        let req = Request::builder()
+            .uri("http://example.com")
+            .header("Content-Length", "42, 42")
+            .body(())
+            .unwrap();
+
+        let (mut call, mut output) = setup_call(req);
+
+        // Try to write the request headers
+        let err = call.write(&mut output).unwrap_err();
+
+        assert!(matches!(
+            err,
+            Error::BadContentLengthHeader | Error::TooManyContentLengthHeaders
+        ));
+    }
+
     // TooManyContentLengthHeaders
     #[test]
     fn test_too_many_content_length_headers() {

--- a/src/error.rs
+++ b/src/error.rs
@@ -224,6 +224,25 @@ mod tests_client {
         assert!(matches!(err, Error::TooManyHostHeaders));
     }
 
+    // BadContentLengthHeader
+    #[test]
+    fn test_signed_content_length_header() {
+        // Content-Length must be plain digits. Rust's integer parsing would
+        // accept a leading sign, the HTTP grammar does not.
+        let req = Request::builder()
+            .uri("http://example.com")
+            .header("Content-Length", "+10")
+            .body(())
+            .unwrap();
+
+        let (mut call, mut output) = setup_call(req);
+
+        // Try to write the request headers
+        let err = call.write(&mut output).unwrap_err();
+
+        assert!(matches!(err, Error::BadContentLengthHeader));
+    }
+
     // TooManyContentLengthHeaders
     #[test]
     fn test_too_many_content_length_headers() {

--- a/src/server/amended.rs
+++ b/src/server/amended.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use http::{HeaderName, HeaderValue, Response, StatusCode, Version, header};
 
 use crate::Error;
-use crate::body::{BodyWriter, parse_content_length};
+use crate::body::{BodyWriter, parse_content_length_value};
 use crate::util::compare_lowercase_ascii;
 
 pub(crate) struct AmendedResponse {
@@ -68,8 +68,12 @@ impl AmendedResponse {
             return Err(Error::TooManyContentLengthHeaders);
         }
 
-        let content_length =
-            parse_content_length(self.headers_get(header::CONTENT_LENGTH).into_iter())?;
+        // We control what we send: a single header line holding a single
+        // number. A comma separated list must not reach the wire.
+        let content_length = self
+            .headers_get(header::CONTENT_LENGTH)
+            .map(|h| parse_content_length_value(h.as_bytes()))
+            .transpose()?;
 
         let has_chunked = self
             .headers_get_all(header::TRANSFER_ENCODING)

--- a/src/server/amended.rs
+++ b/src/server/amended.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use http::{HeaderName, HeaderValue, Response, StatusCode, Version, header};
 
 use crate::Error;
-use crate::body::BodyWriter;
+use crate::body::{BodyWriter, parse_content_length};
 use crate::util::compare_lowercase_ascii;
 
 pub(crate) struct AmendedResponse {
@@ -68,15 +68,8 @@ impl AmendedResponse {
             return Err(Error::TooManyContentLengthHeaders);
         }
 
-        let mut content_length: Option<u64> = None;
-        if let Some(h) = self.headers_get(header::CONTENT_LENGTH) {
-            let n = h
-                .to_str()
-                .ok()
-                .and_then(|s| s.parse::<u64>().ok())
-                .ok_or(Error::BadContentLengthHeader)?;
-            content_length = Some(n);
-        }
+        let content_length =
+            parse_content_length(self.headers_get(header::CONTENT_LENGTH).into_iter())?;
 
         let has_chunked = self
             .headers_get_all(header::TRANSFER_ENCODING)

--- a/src/server/recvreq.rs
+++ b/src/server/recvreq.rs
@@ -96,13 +96,12 @@ impl Reply<RecvRequest> {
         let http10 = request.version() == Version::HTTP_10;
         let method = request.method();
 
-        let header_lookup = |name: http::HeaderName| {
-            let header = request.headers().get(name)?;
-            header.to_str().ok()
-        };
-
-        let reader =
-            BodyReader::for_request(http10, method, self.inner.force_recv_body, &header_lookup)?;
+        let reader = BodyReader::for_request(
+            http10,
+            method,
+            self.inner.force_recv_body,
+            request.headers(),
+        )?;
         self.inner.state.reader = Some(reader);
 
         Ok(Some((input_used, request)))

--- a/src/server/test/state_provide_response.rs
+++ b/src/server/test/state_provide_response.rs
@@ -192,3 +192,20 @@ fn provide_response_with_chunked_encoding() {
         .any(|(name, value)| name == "transfer-encoding" && value == "chunked");
     assert!(has_chunked);
 }
+
+#[test]
+fn provide_response_with_signed_content_length_is_rejected() {
+    let scenario = Scenario::builder().get("/path").build();
+    let reply = scenario.to_provide_response();
+
+    // Content-Length must be plain digits. Rust's integer parsing would
+    // accept a leading sign, the HTTP grammar does not.
+    let response = Response::builder()
+        .status(StatusCode::OK)
+        .header("content-length", "+42")
+        .body(())
+        .unwrap();
+
+    let err = reply.provide(response).unwrap_err();
+    assert_eq!(err, Error::BadContentLengthHeader);
+}

--- a/src/server/test/state_provide_response.rs
+++ b/src/server/test/state_provide_response.rs
@@ -209,3 +209,24 @@ fn provide_response_with_signed_content_length_is_rejected() {
     let err = reply.provide(response).unwrap_err();
     assert_eq!(err, Error::BadContentLengthHeader);
 }
+
+#[test]
+fn provide_response_with_content_length_list_is_rejected() {
+    let scenario = Scenario::builder().get("/path").build();
+    let reply = scenario.to_provide_response();
+
+    // We control what we send. A comma separated list is not a valid
+    // Content-Length to send (RFC 9110 §8.6: the value is 1*DIGIT), so it
+    // must be rejected here rather than written to the wire verbatim.
+    let response = Response::builder()
+        .status(StatusCode::OK)
+        .header("content-length", "42, 42")
+        .body(())
+        .unwrap();
+
+    let err = reply.provide(response).unwrap_err();
+    assert!(matches!(
+        err,
+        Error::BadContentLengthHeader | Error::TooManyContentLengthHeaders
+    ));
+}

--- a/src/server/test/state_recv_request.rs
+++ b/src/server/test/state_recv_request.rs
@@ -225,3 +225,23 @@ fn content_length_with_sign_is_rejected() {
 
     assert_eq!(err, Error::BadContentLengthHeader);
 }
+
+#[test]
+fn content_length_list_with_differing_values_is_rejected() {
+    let mut reply = Reply::new().unwrap();
+
+    let input = b"POST /path HTTP/1.1\r\nhost: example.com\r\ncontent-length: 42, 43\r\n\r\n";
+    let err = reply.try_request(input).unwrap_err();
+
+    assert_eq!(err, Error::TooManyContentLengthHeaders);
+}
+
+#[test]
+fn empty_content_length_is_rejected() {
+    let mut reply = Reply::new().unwrap();
+
+    let input = b"POST /path HTTP/1.1\r\nhost: example.com\r\ncontent-length:\r\n\r\n";
+    let err = reply.try_request(input).unwrap_err();
+
+    assert_eq!(err, Error::BadContentLengthHeader);
+}

--- a/src/server/test/state_recv_request.rs
+++ b/src/server/test/state_recv_request.rs
@@ -1,3 +1,4 @@
+use crate::Error;
 use crate::server::{RecvRequestResult, Reply};
 
 #[test]
@@ -187,4 +188,40 @@ fn proceed_to_send_100_with_get_chunked() {
         RecvRequestResult::Send100(_) => {}
         _ => panic!("Expected Send100 state"),
     }
+}
+
+// Content-Length handling follows RFC 9110 §8.6 / RFC 9112 §6.3 the way
+// libcurl does, see the matching tests for the client response path.
+
+#[test]
+fn duplicate_identical_content_length_is_accepted() {
+    let mut reply = Reply::new().unwrap();
+
+    let input = b"POST /path HTTP/1.1\r\nhost: example.com\r\n\
+        content-length: 42\r\ncontent-length: 042\r\n\r\n";
+    let (input_used, request) = reply.try_request(input).unwrap();
+
+    assert_eq!(input_used, input.len());
+    assert!(request.is_some());
+}
+
+#[test]
+fn duplicate_differing_content_length_is_rejected() {
+    let mut reply = Reply::new().unwrap();
+
+    let input = b"POST /path HTTP/1.1\r\nhost: example.com\r\n\
+        content-length: 42\r\ncontent-length: 43\r\n\r\n";
+    let err = reply.try_request(input).unwrap_err();
+
+    assert_eq!(err, Error::TooManyContentLengthHeaders);
+}
+
+#[test]
+fn content_length_with_sign_is_rejected() {
+    let mut reply = Reply::new().unwrap();
+
+    let input = b"POST /path HTTP/1.1\r\nhost: example.com\r\ncontent-length: +42\r\n\r\n";
+    let err = reply.try_request(input).unwrap_err();
+
+    assert_eq!(err, Error::BadContentLengthHeader);
 }


### PR DESCRIPTION
## Summary

Content-Length handling now follows RFC 9110 §8.6 and RFC 9112 §6.3 the same way libcurl does.

- A value is `1*DIGIT`. Leading zeros are allowed. A sign, whitespace inside the number or any other character is `BadContentLengthHeader`. Rust's integer parsing used to accept `+42`.
- Repeated header lines and comma separated lists are treated identically: every element must parse and all must be the same number, `42` and `042` included. Differing values are `TooManyContentLengthHeaders`. Previously the incoming response and request paths read only the first line through `HeaderMap::get`, so the duplicate check there was unreachable and `Content-Length: 5` followed by `Content-Length: 100` framed the body on 5.
- An empty value, an empty list element and a number that does not fit in `u64` are `BadContentLengthHeader`.

A single `parse_content_length` in `body.rs` implements the rules. `BodyReader::for_request` and `for_response` take the `HeaderMap` instead of a first-value lookup closure, and the outgoing analyzers in `client/amended.rs` and `server/amended.rs` apply the single-value grammar (`parse_content_length_value`): they keep rejecting repeated header lines outright, and a comma separated list is rejected too, since a sender must only emit `1*DIGIT`. Transfer-Encoding handling is unchanged.

Tests: unit tests for the parser covering the full table from the issue, client response tests (identical duplicates accepted, differing lines and a differing list rejected, sign rejected), server request tests for the same cases, outgoing tests for a signed and for a comma separated Content-Length on a client request and on a server response, and wire-level tests for empty values.

Closes #36

