### PR TITLE
Derive `Clone` for `ArrayVec`

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -126,6 +126,7 @@ const HEX: [&str; 256] = [
 ];
 
 /// Simple impl of an array behaving like a vec.
+#[derive(Clone)]
 pub struct ArrayVec<T, const N: usize> {
     len: usize,
     arr: [T; N],


### PR DESCRIPTION
This makes it easier to implement a caching layer for `ureq::ResolvedSocketAddrs`